### PR TITLE
Support for Swift 5.6

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.7
+// swift-tools-version: 5.6
 
 import PackageDescription
 


### PR DESCRIPTION
Hi Jhonatan!

I’d love to add both of these packages (SwiftSafeURL and 
XcodeIssueReporting) to the [Swift Package Index](https://swiftpackageindex.com). Unfortunately we currently don’t support Swift 5.7 packages as it’s still in beta. However, I checked by building them locally with 5.6 and I don’t think you’re using any 5.7 specific features?

Would you consider these PRs to reduce the tools version?

Thanks!